### PR TITLE
Add RSS feed of all blog posts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@astrojs/check": "^0.7.0",
         "@astrojs/mdx": "^3.1.3",
+        "@astrojs/rss": "^4.0.7",
         "@astrojs/tailwind": "^5.1.0",
         "@tailwindcss/container-queries": "^0.1.1",
         "astro": "^4.11.0",
@@ -348,6 +349,15 @@
       },
       "engines": {
         "node": "^18.17.1 || ^20.3.0 || >=21.0.0"
+      }
+    },
+    "node_modules/@astrojs/rss": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.7.tgz",
+      "integrity": "sha512-ZEG55XFB19l+DplUvBISmz04UbjDtKliRO4Y5+ERRhAMjgCVVobEBNE6ZwWG1h6orWUocy4nfPihKXDyB73x9g==",
+      "dependencies": {
+        "fast-xml-parser": "^4.4.0",
+        "kleur": "^4.1.5"
       }
     },
     "node_modules/@astrojs/tailwind": {
@@ -3318,6 +3328,27 @@
       },
       "engines": {
         "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.0.tgz",
+      "integrity": "sha512-kLY3jFlwIYwBNDojclKsNAC12sfD6NwW74QB2CoNGPvtVxjliYehVunB3HYyNi+n4Tt1dAcgwYvmKF/Z18flqg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/fastq": {
@@ -7173,6 +7204,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+    },
     "node_modules/style-to-object": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.4.tgz",
@@ -8521,6 +8557,15 @@
       "integrity": "sha512-Z9IYjuXSArkAUx3N6xj6+Bnvx8OdUSHA8YoOgyepp3+zJmtVYJIl/I18GozdJVW1p5u/CNpl3Km7/gwTJK85cw==",
       "requires": {
         "prismjs": "^1.29.0"
+      }
+    },
+    "@astrojs/rss": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.7.tgz",
+      "integrity": "sha512-ZEG55XFB19l+DplUvBISmz04UbjDtKliRO4Y5+ERRhAMjgCVVobEBNE6ZwWG1h6orWUocy4nfPihKXDyB73x9g==",
+      "requires": {
+        "fast-xml-parser": "^4.4.0",
+        "kleur": "^4.1.5"
       }
     },
     "@astrojs/tailwind": {
@@ -10388,6 +10433,14 @@
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
         "micromatch": "^4.0.4"
+      }
+    },
+    "fast-xml-parser": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.0.tgz",
+      "integrity": "sha512-kLY3jFlwIYwBNDojclKsNAC12sfD6NwW74QB2CoNGPvtVxjliYehVunB3HYyNi+n4Tt1dAcgwYvmKF/Z18flqg==",
+      "requires": {
+        "strnum": "^1.0.5"
       }
     },
     "fastq": {
@@ -12893,6 +12946,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
       "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw=="
+    },
+    "strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "style-to-object": {
       "version": "0.4.4",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@astrojs/check": "^0.7.0",
     "@astrojs/mdx": "^3.1.3",
+    "@astrojs/rss": "^4.0.7",
     "@astrojs/tailwind": "^5.1.0",
     "@tailwindcss/container-queries": "^0.1.1",
     "astro": "^4.11.0",

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,0 +1,34 @@
+import type { APIRoute } from "astro";
+import rss, { type RSSFeedItem } from "@astrojs/rss";
+import { getCollection } from "astro:content";
+
+async function getItems() {
+  const posts = await getCollection("blog");
+
+  return posts.map(
+    (post): RSSFeedItem => ({
+      title: post.data.title,
+      description: post.data.excerpt,
+      pubDate: new Date(post.data.date),
+      link: `blog/${post.slug}`,
+      categories: post.data.tags,
+    }),
+  );
+}
+
+export const GET: APIRoute = async (context) => {
+  return rss({
+    // `<title>` field in output xml
+    title: "Alexander Flink",
+    // `<description>` field in output xml
+    description: "",
+    // Pull in your project "site" from the endpoint context
+    // https://docs.astro.build/en/reference/api-reference/#contextsite
+    site: "https://alexanderflink.com",
+    // Array of `<item>`s in output xml
+    // See "Generating items" section for examples using content collections and glob imports
+    items: await getItems(),
+    // (optional) inject custom xml
+    customData: `<language>en-us</language>`,
+  });
+};


### PR DESCRIPTION
# What? 

Adds a RSS feed of all blog posts (pages rendered subordinate `alexanderflink.com/blog/*`). The RSS feed is available on `alexanderflink.com/rss.xml`.

# Why?

Why not? ;)

# How?

Followed the instructions in the [Astro docs](https://docs.astro.build/en/guides/rss/).

---

- **build: add `@astrojs/rss`**
- **feat(rss.xml.ts): add initial version of `rss.xml.ts`**
